### PR TITLE
fix: handle single entries for `Rep` on `DvPeriod` model

### DIFF
--- a/datapoint/models.py
+++ b/datapoint/models.py
@@ -1,9 +1,9 @@
 import datetime as dt
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import pandas as pd
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.alias_generators import to_camel
 
 from datapoint.utils import parse_timestamp
@@ -56,6 +56,14 @@ class DvPeriod(BaseModel):
     type: str
     value: str
     rep: list[DvRep] = Field(alias="Rep")
+
+    @model_validator(mode="before")
+    @classmethod
+    def ensure_rep_is_a_list(cls, data: Any) -> Any:
+        _rep = data["Rep"]
+        if isinstance(_rep, dict):
+            data["Rep"] = [_rep]  # converts single entry into a list so that it is handled the same as list entries
+        return data
 
 
 class DvLocation(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "met-office-datapoint"
-version = "0.1.0"
+version = "0.1.1"
 description = "Met Office DataPoint client"
 authors = ["Samuel Northover-Naylor"]
 readme = "README.md"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,3 +22,25 @@ def test_location():
         obs_source="FM-13 SHIP",
     )
     assert actual == expected
+
+
+class TestDvPeriod:
+    any_string = "anything"
+    any_int = 42
+    any_float = 0.1
+
+    def test_non_list_rep(self):
+        actual = models.DvPeriod(
+            type=self.any_string,
+            value=self.any_string,
+            Rep={
+                "$": self.any_int,
+                "D": self.any_string,
+                "S": self.any_float,
+                "Wh": self.any_float,
+                "Wp": self.any_float,
+            },
+        )
+
+        assert isinstance(actual.rep, list)
+        assert isinstance(actual.rep[0], models.DvRep)


### PR DESCRIPTION
Convert a single entry (dict) into a list when constructing an instance of the `DvPeriod` model. Prior to this fix, single entries of `Rep` into this model resulted in a validation error, e.g.:

```
Failure Exception: ValidationError: 1 validation error for SiteRep
DV.Location.Period.1.Rep Input should be a valid list
[type=list_type, input_value={'D': 'WSW', 'H': '79.5',... 'St':
'13.8', '$': '0'}, input_type=dict]
```